### PR TITLE
Stub new `isIdle` method to support the `idle` pattern

### DIFF
--- a/src/stub-transport.js
+++ b/src/stub-transport.js
@@ -16,6 +16,10 @@ function StubTransport(options) {
 }
 util.inherits(StubTransport, EventEmitter);
 
+StubTransport.prototype.isIdle = function () {
+	return true;
+};
+
 StubTransport.prototype.send = function(mail, callback) {
 
     if (this.options.error) {


### PR DESCRIPTION
… described [in the nodemailer readme](https://github.com/nodemailer/nodemailer/blob/c4b4623a7f575bae8f4ed56c0df48c22beceb738/README.md#eventidle).
